### PR TITLE
Replace memcached client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'memcached', git: 'https://github.com/arthurnn/memcached', branch: 'master'

--- a/README.md
+++ b/README.md
@@ -1,76 +1,8 @@
-Dalli ElastiCache [![Gem Version](https://badge.fury.io/rb/dalli-elasticache.svg)](http://badge.fury.io/rb/dalli-elasticache) [![Build Status](https://travis-ci.org/ktheory/dalli-elasticache.svg)](https://travis-ci.org/ktheory/dalli-elasticache) [![Code Climate](https://codeclimate.com/github/ktheory/dalli-elasticache.png)](https://codeclimate.com/github/ktheory/dalli-elasticache)
+Memcached ElastiCache
 =================
 
-Use [AWS ElastiCache AutoDiscovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) to automatically configure your [Dalli memcached client](https://github.com/mperham/dalli) with all the nodes in your cluster.
-
-Installation
-------------
-
-Install the [rubygem](https://rubygems.org/gems/dalli-elasticache):
-
-```ruby
-# in your Gemfile
-gem 'memcached'
-```
-
-Setup for Rails 3.x and Newer
------------------------------
-
-Configure your environment-specific application settings:
-
-```ruby
-# in config/environments/production.rb
-endpoint    = "my-cluster-name.abc123.cfg.use1.cache.amazonaws.com:11211"
-elasticache = Dalli::ElastiCache.new(endpoint)
-
-config.cache_store = :dalli_store, elasticache.servers, {:expires_in => 1.day, :compress => true}
-```
-
-Note that the ElastiCache server list will be refreshed each time an app server process starts.
-
-Client Usage
-------------
-
-Create an ElastiCache instance:
-
-```ruby
-config_endpoint = "aaron-scratch.vfdnac.cfg.use1.cache.amazonaws.com:11211"
-
-# Options for configuring the Dalli::Client
-dalli_options = {
-  :expires_in => 24 * 60 * 60,
-  :namespace => "my_app",
-  :compress => true
-}
-
-elasticache = Dalli::ElastiCache.new(config_endpoint, dalli_options)
-```
-
-Fetch information about the Memcached nodes:
-
-```ruby
-# Dalli::Client with configuration from the AutoDiscovery endpoint
-elasticache.client
-# => #<Dalli::Client ... @servers=["aaron-scratch.vfdnac.0001.use1.cache.amazonaws.com:11211", ...]>
-
-# Node addresses
-elasticache.servers
-# => ["aaron-scratch.vfdnac.0001.use1.cache.amazonaws.com:11211", "aaron-scratch.vfdnac.0002.use1.cache.amazonaws.com:11211"]
-
-# Number of times the cluster configuration has changed
-elasticache.version
-# => 12
-
-# Memcached version of the cluster
-elasticache.engine_version
-# => "1.4.14"
-
-# Refresh data from the endpoint
-elasticache.refresh
-
-# Refresh and get client with new configuration
-elasticache.refresh.client
-```
+Use [AWS ElastiCache AutoDiscovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) to automatically configure your [memcached](https://github.com/arthurnn/memcached) client with all the nodes in your cluster.  
+Forked from [ktheory/dalli-elasticache](https://github.com/ktheory/dalli-elasticache).
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Memcached ElastiCache
+Memcached ElastiCache [![Build Status](https://travis-ci.org/hoco/memcached-elasticache.svg?branch=master)](https://travis-ci.org/hoco/memcached-elasticache)
 =================
 
 Use [AWS ElastiCache AutoDiscovery](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.html) to automatically configure your [memcached](https://github.com/arthurnn/memcached) client with all the nodes in your cluster.  

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the [rubygem](https://rubygems.org/gems/dalli-elasticache):
 
 ```ruby
 # in your Gemfile
-gem 'dalli-elasticache'
+gem 'memcached'
 ```
 
 Setup for Rails 3.x and Newer

--- a/lib/dalli/elasticache/version.rb
+++ b/lib/dalli/elasticache/version.rb
@@ -1,5 +1,0 @@
-module Dalli
-  class ElastiCache
-    VERSION = "0.2.0"
-  end
-end

--- a/lib/memcached-elasticache.rb
+++ b/lib/memcached-elasticache.rb
@@ -1,2 +1,2 @@
 # Support default bundler require path
-require 'dalli/elasticache'
+require 'memcached/elasticache'

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -6,137 +6,139 @@ require 'memcached/elasticache/auto_discovery/config_response'
 require 'memcached/elasticache/auto_discovery/stats_response'
 
 module Memcached
-  class ElastiCache
-    attr_reader :endpoint, :options
+  module Elasticache
+    class Client
+      attr_reader :endpoint, :options
 
-    def initialize(config_endpoint, options={})
-      @refresh_interval = options.delete(:refresh_interval) || 60
-      @max_retry_count = options.delete(:max_retry_count) || 1
-      @enable_legacy_ec = options.delete(:enable_legacy_ec) || false
-      @default_ttl = options[:ttl] || 0
-      @options = options
+      def initialize(config_endpoint, options={})
+        @refresh_interval = options.delete(:refresh_interval) || 60
+        @max_retry_count = options.delete(:max_retry_count) || 1
+        @enable_legacy_ec = options.delete(:enable_legacy_ec) || false
+        @default_ttl = options[:ttl] || 0
+        @options = options
 
-      @last_updated_at = Time.now
-      @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy_ec)
-      @client = Memcached::Client.new(cluster_servers, @options)
-    end
-
-    def clone
-      options = @options.dup.merge(
-        refresh_interval: @refresh_interval,
-        max_retry_count: @max_retry_count,
-        enable_legacy_ec: @enable_legacy_ec
-      )
-      Memcached::ElastiCache.new(config_endpoint, options)
-    end
-
-    # memcached client methods
-
-    def flush
-      refresh_with { @client.flush }
-    end
-
-    def set(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
-      refresh_with { @client.set(key, value, ttl: ttl, raw: raw, flags: flags) }
-    end
-
-    def get(key, raw: nil)
-      refresh_with { @client.get(key, raw: raw) }
-    end
-
-    def get_multi(keys, raw: nil)
-      refresh_with { @client.get_multi(keys, raw: raw) }
-    end
-
-    def delete(key)
-      refresh_with { @client.delete(key) }
-    end
-
-    def add(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
-      refresh_with { @client.add(key, value, ttl: ttl, raw: raw, flags: flags) }
-    end
-
-    def increment(key, offset = 1)
-      refresh_with { @client.increment(key, offset) }
-    end
-
-    def decrement(key, offset = 1)
-      refresh_with { @client.decrement(key, offset) }
-    end
-
-    def exist(key)
-      refresh_with { @client.exist(key) }
-    end
-
-    def replace(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
-      refresh_with { @client.replace(key, value, ttl: ttl, raw: raw, flags: flags) }
-    end
-
-    def prepend(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
-      refresh_with { @client.prepend(key, value, ttl: ttl, flags: flags) }
-    end
-
-    def append(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
-      refresh_with { @client.append(key, value, ttl: ttl, flags: flags) }
-    end
-
-    def namespace
-      @client.namespace
-    end
-
-    def namespace=(value)
-      @client.namespace = value
-    end
-
-    def touch(key, ttl = @default_ttl)
-      refresh_with { @client.touch(key, ttl) }
-    end
-
-    def reset
-      @client.reset
-    end
-
-    private
-
-    def refresh_with
-      if (Time.now - @last_updated_at) > @refresh_interval
         @last_updated_at = Time.now
-        refresh
-      end
-
-      retry_count = 0
-      begin
-        yield
-      rescue Memcached::ConnectionFailure => e
-        if retry_count < @max_retry_count
-          retry_count += 1
-          refresh
-          retry
-        else
-          raise e
-        end
-      end
-    end
-
-    # List of cluster server nodes with ip addresses and ports
-    # Always use host name instead of private elasticache IPs as internal IPs can change after a node is rebooted
-    def cluster_servers
-      endpoint.config.nodes.map { |h| "#{h[:host]}:#{h[:port]}" }
-    end
-
-    # Refresh list of cache nodes and their connections
-    def refresh
-      old_endpoint = endpoint
-      @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy)
-
-      if old_endpoint.config.nodes != @endpoint.config.nodes
-        @client.reset
+        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy_ec)
         @client = Memcached::Client.new(cluster_servers, @options)
       end
-    end
 
-    def config_endpoint
-      "#{endpoint.host}:#{endpoint.port}"
+      def clone
+        options = @options.dup.merge(
+          refresh_interval: @refresh_interval,
+          max_retry_count: @max_retry_count,
+          enable_legacy_ec: @enable_legacy_ec
+        )
+        Memcached::Elasticache::Client.new(config_endpoint, options)
+      end
+
+      # memcached client methods
+
+      def flush
+        refresh_with { @client.flush }
+      end
+
+      def set(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+        refresh_with { @client.set(key, value, ttl: ttl, raw: raw, flags: flags) }
+      end
+
+      def get(key, raw: nil)
+        refresh_with { @client.get(key, raw: raw) }
+      end
+
+      def get_multi(keys, raw: nil)
+        refresh_with { @client.get_multi(keys, raw: raw) }
+      end
+
+      def delete(key)
+        refresh_with { @client.delete(key) }
+      end
+
+      def add(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+        refresh_with { @client.add(key, value, ttl: ttl, raw: raw, flags: flags) }
+      end
+
+      def increment(key, offset = 1)
+        refresh_with { @client.increment(key, offset) }
+      end
+
+      def decrement(key, offset = 1)
+        refresh_with { @client.decrement(key, offset) }
+      end
+
+      def exist(key)
+        refresh_with { @client.exist(key) }
+      end
+
+      def replace(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+        refresh_with { @client.replace(key, value, ttl: ttl, raw: raw, flags: flags) }
+      end
+
+      def prepend(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
+        refresh_with { @client.prepend(key, value, ttl: ttl, flags: flags) }
+      end
+
+      def append(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
+        refresh_with { @client.append(key, value, ttl: ttl, flags: flags) }
+      end
+
+      def namespace
+        @client.namespace
+      end
+
+      def namespace=(value)
+        @client.namespace = value
+      end
+
+      def touch(key, ttl = @default_ttl)
+        refresh_with { @client.touch(key, ttl) }
+      end
+
+      def reset
+        @client.reset
+      end
+
+      private
+
+      def refresh_with
+        if (Time.now - @last_updated_at) > @refresh_interval
+          @last_updated_at = Time.now
+          refresh
+        end
+
+        retry_count = 0
+        begin
+          yield
+        rescue Memcached::ConnectionFailure => e
+          if retry_count < @max_retry_count
+            retry_count += 1
+            refresh
+            retry
+          else
+            raise e
+          end
+        end
+      end
+
+      # List of cluster server nodes with ip addresses and ports
+      # Always use host name instead of private elasticache IPs as internal IPs can change after a node is rebooted
+      def cluster_servers
+        endpoint.config.nodes.map { |h| "#{h[:host]}:#{h[:port]}" }
+      end
+
+      # Refresh list of cache nodes and their connections
+      def refresh
+        old_endpoint = endpoint
+        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy)
+
+        if old_endpoint.config.nodes != @endpoint.config.nodes
+          @client.reset
+          @client = Memcached::Client.new(cluster_servers, @options)
+        end
+      end
+
+      def config_endpoint
+        "#{endpoint.host}:#{endpoint.port}"
+      end
     end
   end
 end

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -13,31 +13,12 @@ module Memcached
       @refresh_interval = options.delete(:refresh_interval) || 60
       @max_retry_count = options.delete(:max_retry_count) || 1
       @enable_legacy_ec = options.delete(:enable_legacy_ec) || false
+      @default_ttl = options[:ttl] || 0
       @options = options
 
       @last_updated_at = Time.now
       @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy_ec)
       @client = Memcached::Client.new(cluster_servers, @options)
-    end
-
-    def method_missing(method, *args, &block)
-      if (Time.now - @last_updated_at) > @refresh_interval
-        @last_updated_at = Time.now
-        refresh
-      end
-
-      retry_count = 0
-      begin
-        @client.public_send(method, *args)
-      rescue Memcached::ConnectionFailure => e
-        if retry_count < @max_retry_count
-          retry_count += 1
-          refresh
-          retry
-        else
-          raise e
-        end
-      end
     end
 
     def clone
@@ -49,7 +30,93 @@ module Memcached
       Memcached::ElastiCache.new(config_endpoint, options)
     end
 
+    # memcached client methods
+
+    def flush
+      refresh_with { @client.flush }
+    end
+
+    def set(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+      refresh_with { @client.set(key, value, ttl: ttl, raw: raw, flags: flags) }
+    end
+
+    def get(key, raw: nil)
+      refresh_with { @client.get(key, raw: raw) }
+    end
+
+    def get_multi(keys, raw: nil)
+      refresh_with { @client.get_multi(keys, raw: raw) }
+    end
+
+    def delete(key)
+      refresh_with { @client.delete(key) }
+    end
+
+    def add(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+      refresh_with { @client.add(key, value, ttl: ttl, raw: raw, flags: flags) }
+    end
+
+    def increment(key, offset = 1)
+      refresh_with { @client.increment(key, offset) }
+    end
+
+    def decrement(key, offset = 1)
+      refresh_with { @client.decrement(key, offset) }
+    end
+
+    def exist(key)
+      refresh_with { @client.exist(key) }
+    end
+
+    def replace(key, value, ttl: @default_ttl, raw: false, flags: Memcached::Client::FLAGS)
+      refresh_with { @client.replace(key, value, ttl: ttl, raw: raw, flags: flags) }
+    end
+
+    def prepend(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
+      refresh_with { @client.prepend(key, value, ttl: ttl, flags: flags) }
+    end
+
+    def append(key, value, ttl: @default_ttl, flags: Memcached::Client::FLAGS)
+      refresh_with { @client.append(key, value, ttl: ttl, flags: flags) }
+    end
+
+    def namespace
+      @client.namespace
+    end
+
+    def namespace=(value)
+      @client.namespace = value
+    end
+
+    def touch(key, ttl = @default_ttl)
+      refresh_with { @client.touch(key, ttl) }
+    end
+
+    def reset
+      @client.reset
+    end
+
     private
+
+    def refresh_with
+      if (Time.now - @last_updated_at) > @refresh_interval
+        @last_updated_at = Time.now
+        refresh
+      end
+
+      retry_count = 0
+      begin
+        yield
+      rescue Memcached::ConnectionFailure => e
+        if retry_count < @max_retry_count
+          retry_count += 1
+          refresh
+          retry
+        else
+          raise e
+        end
+      end
+    end
 
     # List of cluster server nodes with ip addresses and ports
     # Always use host name instead of private elasticache IPs as internal IPs can change after a node is rebooted

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -7,7 +7,7 @@ require 'memcached/elasticache/auto_discovery/stats_response'
 
 module Memcached
   class ElastiCache
-    attr_reader :endpoint, :options
+    attr_reader :endpoint, :options, :client
 
     def initialize(config_endpoint, options={})
       @refresh_interval = options.delete(:refresh_interval) || 60

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -54,9 +54,8 @@ module Memcached
       @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new("#{endpoint.host}:#{endpoint.port}", @enable_legacy)
 
       if old_endpoint.config.nodes != @endpoint.config.nodes
-        old_client = @client
+        @client.reset
         @client = Memcached::Client.new(cluster_servers, @options)
-        old_client.reset
       end
     end
   end

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -1,22 +1,22 @@
-require 'dalli'
+require 'memcached'
 require 'socket'
-require 'dalli/elasticache/version'
-require 'dalli/elasticache/auto_discovery/endpoint'
-require 'dalli/elasticache/auto_discovery/config_response'
-require 'dalli/elasticache/auto_discovery/stats_response'
+require 'memcached/elasticache/version'
+require 'memcached/elasticache/auto_discovery/endpoint'
+require 'memcached/elasticache/auto_discovery/config_response'
+require 'memcached/elasticache/auto_discovery/stats_response'
 
-module Dalli
+class Memcached
   class ElastiCache
     attr_reader :endpoint, :options
     
     def initialize(config_endpoint, options={})
-      @endpoint = Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
+      @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
       @options = options
     end
     
-    # Dalli::Client configured to connect to the cluster's nodes
+    # Memcached::Client configured to connect to the cluster's nodes
     def client
-      Dalli::Client.new(servers, options)
+      Memcached.new(servers, options)
     end
     
     # The number of times the cluster configuration has been changed
@@ -40,7 +40,7 @@ module Dalli
     # Clear all cached data from the cluster endpoint
     def refresh
       config_endpoint = "#{endpoint.host}:#{endpoint.port}"
-      @endpoint = Dalli::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
+      @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
       
       self
     end

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -13,20 +13,18 @@ module Memcached
       def initialize(config_endpoint, options={})
         @refresh_interval = options.delete(:refresh_interval) || 60
         @max_retry_count = options.delete(:max_retry_count) || 1
-        @enable_legacy_ec = options.delete(:enable_legacy_ec) || false
         @default_ttl = options[:ttl] || 0
         @options = options
 
         @last_updated_at = Time.now
-        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy_ec)
+        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
         @client = Memcached::Client.new(cluster_servers, @options)
       end
 
       def clone
         options = @options.dup.merge(
           refresh_interval: @refresh_interval,
-          max_retry_count: @max_retry_count,
-          enable_legacy_ec: @enable_legacy_ec
+          max_retry_count: @max_retry_count
         )
         Memcached::Elasticache::Client.new(config_endpoint, options)
       end
@@ -124,7 +122,7 @@ module Memcached
       # Refresh list of cache nodes and their connections
       def refresh
         old_endpoint = endpoint
-        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint, @enable_legacy)
+        @endpoint = Memcached::Elasticache::AutoDiscovery::Endpoint.new(config_endpoint)
 
         if old_endpoint.config.nodes != @endpoint.config.nodes
           @client.reset

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -10,6 +10,11 @@ module Memcached
     class Client
       attr_reader :endpoint, :options
 
+      # Initialize ElastiCache client
+      # @param [String] config_endpoint ElastiCache config endpoint strings like "my-host.cache.aws.com:11211"
+      # @option [Integer] :refresh_interval second-scale interval of refreshing cluster endpoints
+      # @option [Integer] :max_retry_count max retry times to command and refresh cluster endpoints
+      # @option [Integer] :ttl default TTL used by Memcached::Client
       def initialize(config_endpoint, options={})
         @refresh_interval = options.delete(:refresh_interval) || 60
         @max_retry_count = options.delete(:max_retry_count) || 1

--- a/lib/memcached/elasticache.rb
+++ b/lib/memcached/elasticache.rb
@@ -85,10 +85,6 @@ module Memcached
         @client.namespace
       end
 
-      def namespace=(value)
-        @client.namespace = value
-      end
-
       def touch(key, ttl = @default_ttl)
         refresh_with { @client.touch(key, ttl) }
       end

--- a/lib/memcached/elasticache/auto_discovery/config_response.rb
+++ b/lib/memcached/elasticache/auto_discovery/config_response.rb
@@ -1,4 +1,4 @@
-class Memcached
+module Memcached
   module Elasticache
     module AutoDiscovery
       

--- a/lib/memcached/elasticache/auto_discovery/config_response.rb
+++ b/lib/memcached/elasticache/auto_discovery/config_response.rb
@@ -1,4 +1,4 @@
-module Dalli
+class Memcached
   module Elasticache
     module AutoDiscovery
       

--- a/lib/memcached/elasticache/auto_discovery/endpoint.rb
+++ b/lib/memcached/elasticache/auto_discovery/endpoint.rb
@@ -2,73 +2,74 @@ module Memcached
   module Elasticache
     module AutoDiscovery
       class Endpoint
-        
+
         # Endpoint configuration
         attr_reader :host
         attr_reader :port
-    
+
         # Matches Strings like "my-host.cache.aws.com:11211"
         ENDPOINT_REGEX = /([-.a-zA-Z0-9]+):(\d+)/
-    
+
         STATS_COMMAND  = "stats\r\n"
         CONFIG_COMMAND = "config get cluster\r\n"
         # Legacy command for version < 1.4.14
         OLD_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
-    
-        def initialize(endpoint)
+
+        def initialize(endpoint, enable_legacy_ec)
           ENDPOINT_REGEX.match(endpoint) do |m|
             @host = m[1]
             @port = m[2].to_i
           end
+          @enable_legacy_ec = enable_legacy_ec
         end
-    
+
         # A cached ElastiCache::StatsResponse
         def stats
           @stats ||= get_stats_from_remote
         end
-    
+
         # A cached ElastiCache::ConfigResponse
         def config
           @config ||= get_config_from_remote
         end
-    
+
         # The memcached engine version
         def engine_version
           stats.version
         end
-    
+
         protected
-    
+
         def with_socket(&block)
           TCPSocket.new(config_host, config_port)
         end
-    
+
         def get_stats_from_remote
           data = remote_command(STATS_COMMAND)
           StatsResponse.new(data)
         end
-    
+
         def get_config_from_remote
-          if engine_version < Gem::Version.new("1.4.14")
+          if @enable_legacy_ec && engine_version < Gem::Version.new("1.4.14")
             data = remote_command(OLD_CONFIG_COMMAND)
           else
             data = remote_command(CONFIG_COMMAND)
           end
           ConfigResponse.new(data)
         end
-      
+
         # Send an ASCII command to the endpoint
         #
         # Returns the raw response as a String
         def remote_command(command)
           socket = TCPSocket.new(@host, @port)
           socket.puts command
-        
+
           data = ""
           until (line = socket.readline) =~ /END/
             data << line
           end
-        
+
           socket.close
           data
         end

--- a/lib/memcached/elasticache/auto_discovery/endpoint.rb
+++ b/lib/memcached/elasticache/auto_discovery/endpoint.rb
@@ -1,4 +1,4 @@
-module Dalli
+class Memcached
   module Elasticache
     module AutoDiscovery
       class Endpoint

--- a/lib/memcached/elasticache/auto_discovery/endpoint.rb
+++ b/lib/memcached/elasticache/auto_discovery/endpoint.rb
@@ -1,4 +1,4 @@
-class Memcached
+module Memcached
   module Elasticache
     module AutoDiscovery
       class Endpoint

--- a/lib/memcached/elasticache/auto_discovery/endpoint.rb
+++ b/lib/memcached/elasticache/auto_discovery/endpoint.rb
@@ -12,15 +12,12 @@ module Memcached
 
         STATS_COMMAND  = "stats\r\n"
         CONFIG_COMMAND = "config get cluster\r\n"
-        # Legacy command for version < 1.4.14
-        OLD_CONFIG_COMMAND = "get AmazonElastiCache:cluster\r\n"
 
-        def initialize(endpoint, enable_legacy_ec)
+        def initialize(endpoint)
           ENDPOINT_REGEX.match(endpoint) do |m|
             @host = m[1]
             @port = m[2].to_i
           end
-          @enable_legacy_ec = enable_legacy_ec
         end
 
         # A cached ElastiCache::StatsResponse
@@ -50,11 +47,7 @@ module Memcached
         end
 
         def get_config_from_remote
-          if @enable_legacy_ec && engine_version < Gem::Version.new("1.4.14")
-            data = remote_command(OLD_CONFIG_COMMAND)
-          else
-            data = remote_command(CONFIG_COMMAND)
-          end
+          data = remote_command(CONFIG_COMMAND)
           ConfigResponse.new(data)
         end
 

--- a/lib/memcached/elasticache/auto_discovery/stats_response.rb
+++ b/lib/memcached/elasticache/auto_discovery/stats_response.rb
@@ -1,4 +1,4 @@
-class Memcached
+module Memcached
   module Elasticache
     module AutoDiscovery
       

--- a/lib/memcached/elasticache/auto_discovery/stats_response.rb
+++ b/lib/memcached/elasticache/auto_discovery/stats_response.rb
@@ -1,24 +1,24 @@
 module Memcached
   module Elasticache
     module AutoDiscovery
-      
+
       # This class wraps the raw ASCII response from an Auto Discovery endpoint
       # and provides methods for extracting data from that response.
       #
       # http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html
-      
+
       class StatsResponse
-        
+
         # The raw response text
         attr_reader :text
-        
+
         # Matches the version line of the response
         VERSION_REGEX = /^STAT version ([0-9.]+)\s*$/
-        
+
         def initialize(response_text)
           @text = response_text.to_s
         end
-        
+
         # Extract the engine version stat
         #
         # Returns a Gem::Version

--- a/lib/memcached/elasticache/auto_discovery/stats_response.rb
+++ b/lib/memcached/elasticache/auto_discovery/stats_response.rb
@@ -1,4 +1,4 @@
-module Dalli
+class Memcached
   module Elasticache
     module AutoDiscovery
       

--- a/lib/memcached/elasticache/version.rb
+++ b/lib/memcached/elasticache/version.rb
@@ -1,0 +1,5 @@
+class Memcached
+  class ElastiCache
+    VERSION = "0.1.0"
+  end
+end

--- a/lib/memcached/elasticache/version.rb
+++ b/lib/memcached/elasticache/version.rb
@@ -1,4 +1,4 @@
-class Memcached
+module Memcached
   class ElastiCache
     VERSION = "0.1.0"
   end

--- a/memcached-elasticache.gemspec
+++ b/memcached-elasticache.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_dependency 'memcached', ">= 1.8.0" # ??
+  s.add_dependency 'memcached', ">= 2.0.0.alpha" # ??
 end

--- a/memcached-elasticache.gemspec
+++ b/memcached-elasticache.gemspec
@@ -2,17 +2,17 @@
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 
-require 'dalli/elasticache/version'
+require 'memcached/elasticache/version'
 
 Gem::Specification.new do |s|
-  s.name     = 'dalli-elasticache'
-  s.version  = Dalli::ElastiCache::VERSION
+  s.name     = 'memcached-elasticache'
+  s.version  = Memcached::ElastiCache::VERSION
   s.licenses = ['MIT']
   
-  s.summary     = "Configure Dalli clients with ElastiCache's AutoDiscovery"
+  s.summary     = "Configure memcached client (an interface to the libmemcached) with ElastiCache's AutoDiscovery"
   s.description = <<-EOS
     This gem provides an interface for fetching cluster information from an AWS
-    ElastiCache AutoDiscovery server and configuring a Dalli client to connect
+    ElastiCache AutoDiscovery server and configuring a memcached client to connect
     to all nodes in the cache cluster.
   EOS
   
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_dependency 'dalli', ">= 1.0.0" # ??
+  s.add_dependency 'memcached', ">= 1.8.0" # ??
 end

--- a/spec/config_response_spec.rb
+++ b/spec/config_response_spec.rb
@@ -5,28 +5,28 @@ describe 'Memcached::Elasticache::AutoDiscovery::ConfigResponse' do
     text = "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n"
     Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(text)
   end
-  
+
   describe '#version' do
     it 'parses version' do
-      response.version.should == 12
+      expect(response.version).to eq 12
     end
   end
 
   describe '#nodes' do
     it 'parses hosts' do
-      response.nodes.map{|s| s[:host]}.should == [
+      expect(response.nodes.map{|s| s[:host]}).to eq [
         "mycluster.0001.cache.amazonaws.com",
         "mycluster.0002.cache.amazonaws.com",
         "mycluster.0003.cache.amazonaws.com"
       ]
     end
-  
+
     it 'parses ip addresses' do
-      response.nodes.map{|s| s[:ip]}.should == ["10.112.21.1", "10.112.21.2", "10.112.21.3"]
+      expect(response.nodes.map{|s| s[:ip]}).to eq ["10.112.21.1", "10.112.21.2", "10.112.21.3"]
     end
-  
+
     it 'parses ports' do
-      response.nodes.map{|s| s[:port]}.should == [11211, 11211, 11211]
+      expect(response.nodes.map{|s| s[:port]}).to eq [11211, 11211, 11211]
     end
   end
 end

--- a/spec/config_response_spec.rb
+++ b/spec/config_response_spec.rb
@@ -1,9 +1,9 @@
 require_relative 'spec_helper'
 
-describe 'Dalli::Elasticache::AutoDiscovery::ConfigResponse' do
+describe 'Memcached::Elasticache::AutoDiscovery::ConfigResponse' do
   let :response do
     text = "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n"
-    Dalli::Elasticache::AutoDiscovery::ConfigResponse.new(text)
+    Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(text)
   end
   
   describe '#version' do

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -15,7 +15,7 @@ describe 'Memcached::ElastiCache::Endpoint' do
 
   before do
     Memcached::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response)
-    Memcached.should_receive(:new).and_return('dummy_client')
+    Memcached::Client.should_receive(:new).and_return('dummy_client')
   end
 
   describe '.new' do

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -237,16 +237,6 @@ describe 'Memcached::Elasticache::Endpoint' do
       end
     end
 
-    describe '#namespace=' do
-      let(:name) { 'foo' }
-      subject { client.namespace = name }
-
-      it 'calls memcached #namespace' do
-        expect(m_client).to receive(:namespace=).with(name)
-        subject
-      end
-    end
-
     describe '#touch' do
       subject { client.touch(key, ttl) }
 

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -13,6 +13,11 @@ describe 'Memcached::ElastiCache::Endpoint' do
   let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
   let(:response) { Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
 
+  before do
+    Memcached::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response)
+    Memcached.should_receive(:new).and_return('dummy_client')
+  end
+
   describe '.new' do
     it 'builds endpoint' do
       cache.endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
@@ -25,38 +30,7 @@ describe 'Memcached::ElastiCache::Endpoint' do
       cache.options[:compress].should == true
     end
   end
-  
-  describe '#client' do
-    it 'builds with node list'
-    it 'builds with options'
-  end
-  
-  describe '#servers' do
-    before { Memcached::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response) }
 
-    it 'lists addresses and ports' do
-      cache.servers.should == ["mycluster.0001.cache.amazonaws.com:11211", "mycluster.0002.cache.amazonaws.com:11211", "mycluster.0003.cache.amazonaws.com:11211"]
-    end
+  describe '#method_missing' do
   end
-  
-  describe '#version' do
-  end
-  
-  describe '#engine_version' do
-  end
-  
-  describe '#refresh' do
-    it 'clears endpoint configuration' do
-      stale_endpoint = cache.endpoint
-      cache.refresh.endpoint.should_not === stale_endpoint
-    end
-    
-    it 'builds endpoint with same configuration' do
-      stale_endpoint = cache.endpoint
-      cache.refresh
-      cache.endpoint.host.should == stale_endpoint.host
-      cache.endpoint.port.should == stale_endpoint.port
-    end
-  end
-  
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -23,9 +23,9 @@ describe 'Memcached::ElastiCache::Endpoint' do
   describe '.new' do
     let(:options) {
       {
-        :expires_in => 24*60*60,
-        :namespace => "my_app",
-        :compress => true
+        expires_in: 24*60*60,
+        namespace: 'my_app',
+        compress: true
       }
     }
     it 'builds endpoint' do
@@ -86,6 +86,33 @@ describe 'Memcached::ElastiCache::Endpoint' do
       it 'raises error' do
         expect { subject }.to raise_error(Memcached::ConnectionFailure)
       end
+    end
+  end
+
+  describe '#clone' do
+    subject { cache.clone }
+
+    let(:client_options) {
+      {
+        expires_in: 24*60*60,
+        namespace: 'my_app',
+        compress: true
+      }
+    }
+    let(:ec_options) {
+      {
+        refresh_interval: 10,
+        max_retry_count: 5,
+        enable_legacy_ec: true
+      }
+    }
+    let(:options) { client_options.merge ec_options }
+
+    it 'clones client has same options' do
+      expect(subject.options).to eq client_options
+      expect(subject.instance_variable_get(:@refresh_interval)).to eq ec_options[:refresh_interval]
+      expect(subject.instance_variable_get(:@max_retry_count)).to eq ec_options[:max_retry_count]
+      expect(subject.instance_variable_get(:@enable_legacy_ec)).to eq ec_options[:enable_legacy_ec]
     end
   end
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -48,8 +48,7 @@ describe 'Memcached::Elasticache::Endpoint' do
     let(:ec_options) {
       {
         refresh_interval: 10,
-        max_retry_count: 5,
-        enable_legacy_ec: true
+        max_retry_count: 5
       }
     }
     let(:options) { client_options.merge ec_options }
@@ -58,7 +57,6 @@ describe 'Memcached::Elasticache::Endpoint' do
       expect(subject.options).to eq client_options
       expect(subject.instance_variable_get(:@refresh_interval)).to eq ec_options[:refresh_interval]
       expect(subject.instance_variable_get(:@max_retry_count)).to eq ec_options[:max_retry_count]
-      expect(subject.instance_variable_get(:@enable_legacy_ec)).to eq ec_options[:enable_legacy_ec]
       expect(subject.instance_variable_get(:@default_ttl)).to eq client_options[:ttl]
     end
   end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'spec_helper'
 require 'ostruct'
 
-describe 'Memcached::ElastiCache::Endpoint' do
-  let(:client) { Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options) }
+describe 'Memcached::Elasticache::Endpoint' do
+  let(:client) { Memcached::Elasticache::Client.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options) }
 
   let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
   let(:response) { Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -1,17 +1,17 @@
 require_relative 'spec_helper'
 
-describe 'Dalli::ElastiCache::Endpoint' do
+describe 'Memcached::ElastiCache::Endpoint' do
   let(:cache) do
     options = {
       :expires_in => 24*60*60,
       :namespace => "my_app",
       :compress => true
     }
-    Dalli::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options)
+    Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options)
   end
 
   let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
-  let(:response) { Dalli::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
+  let(:response) { Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
 
   describe '.new' do
     it 'builds endpoint' do
@@ -19,7 +19,7 @@ describe 'Dalli::ElastiCache::Endpoint' do
       cache.endpoint.port.should == 11211
     end
     
-    it 'stores Dalli options' do
+    it 'stores Memcached options' do
       cache.options[:expires_in].should == 24*60*60
       cache.options[:namespace].should == "my_app"
       cache.options[:compress].should == true
@@ -32,7 +32,7 @@ describe 'Dalli::ElastiCache::Endpoint' do
   end
   
   describe '#servers' do
-    before { Dalli::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response) }
+    before { Memcached::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response) }
 
     it 'lists addresses and ports' do
       cache.servers.should == ["mycluster.0001.cache.amazonaws.com:11211", "mycluster.0002.cache.amazonaws.com:11211", "mycluster.0003.cache.amazonaws.com:11211"]

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -1,36 +1,91 @@
 require_relative 'spec_helper'
+require 'ostruct'
 
 describe 'Memcached::ElastiCache::Endpoint' do
-  let(:cache) do
-    options = {
-      :expires_in => 24*60*60,
-      :namespace => "my_app",
-      :compress => true
-    }
-    Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options)
-  end
+  let(:cache) { Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options) }
 
   let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
   let(:response) { Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
+  let(:options) { {} }
+  let(:dummy_client) {
+    Class.new {
+      def dummy_command
+        'dummy'
+      end
+    }.new
+  }
 
   before do
-    Memcached::Elasticache::AutoDiscovery::Endpoint.any_instance.should_receive(:get_config_from_remote).and_return(response)
-    Memcached::Client.should_receive(:new).and_return('dummy_client')
+    allow_any_instance_of(Memcached::Elasticache::AutoDiscovery::Endpoint).to receive(:get_config_from_remote).and_return(response)
+    allow(Memcached::Client).to receive(:new).and_return(dummy_client)
   end
 
   describe '.new' do
+    let(:options) {
+      {
+        :expires_in => 24*60*60,
+        :namespace => "my_app",
+        :compress => true
+      }
+    }
     it 'builds endpoint' do
-      cache.endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
-      cache.endpoint.port.should == 11211
+      expect(cache.endpoint.host).to eq "my-cluster.cfg.use1.cache.amazonaws.com"
+      expect(cache.endpoint.port).to eq 11211
     end
-    
+
     it 'stores Memcached options' do
-      cache.options[:expires_in].should == 24*60*60
-      cache.options[:namespace].should == "my_app"
-      cache.options[:compress].should == true
+      expect(cache.options[:expires_in]).to eq 24*60*60
+      expect(cache.options[:namespace]).to eq "my_app"
+      expect(cache.options[:compress]).to be true
     end
   end
 
   describe '#method_missing' do
+    subject { cache.dummy_command }
+
+    context 'on refresh time' do
+      let(:options) { { refresh_interval: -1 } }
+
+      it 'refreshes nodes' do
+        expect(cache).to receive(:refresh)
+        subject
+      end
+      it 'send command' do
+        expect(cache).to receive(:dummy_command)
+        subject
+      end
+    end
+    context 'not on refresh time' do
+      it 'doesnt refresh nodes' do
+        expect(cache).not_to receive(:refresh)
+        subject
+      end
+      it 'sends command' do
+        expect(cache).to receive(:dummy_command)
+        subject
+      end
+    end
+
+    context 'connection failed' do
+      let(:dummy_client) {
+        Class.new {
+          def dummy_command
+            raise Memcached::ConnectionFailure
+          end
+        }.new
+      }
+
+      it 'refreshes nodes once' do
+        expect(cache).to receive(:refresh).once
+        begin
+          subject
+        rescue
+        end
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(Memcached::ConnectionFailure)
+      end
+    end
   end
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -2,22 +2,16 @@ require_relative 'spec_helper'
 require 'ostruct'
 
 describe 'Memcached::ElastiCache::Endpoint' do
-  let(:cache) { Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options) }
+  let(:client) { Memcached::ElastiCache.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", options) }
 
   let(:config_text) { "CONFIG cluster 0 141\r\n12\nmycluster.0001.cache.amazonaws.com|10.112.21.1|11211 mycluster.0002.cache.amazonaws.com|10.112.21.2|11211 mycluster.0003.cache.amazonaws.com|10.112.21.3|11211\n\r\n" }
   let(:response) { Memcached::Elasticache::AutoDiscovery::ConfigResponse.new(config_text) }
   let(:options) { {} }
-  let(:dummy_client) {
-    Class.new {
-      def dummy_command
-        'dummy'
-      end
-    }.new
-  }
+  let(:m_client) { {} }
 
   before do
     allow_any_instance_of(Memcached::Elasticache::AutoDiscovery::Endpoint).to receive(:get_config_from_remote).and_return(response)
-    allow(Memcached::Client).to receive(:new).and_return(dummy_client)
+    allow(Memcached::Client).to receive(:new).and_return(m_client)
   end
 
   describe '.new' do
@@ -29,74 +23,26 @@ describe 'Memcached::ElastiCache::Endpoint' do
       }
     }
     it 'builds endpoint' do
-      expect(cache.endpoint.host).to eq "my-cluster.cfg.use1.cache.amazonaws.com"
-      expect(cache.endpoint.port).to eq 11211
+      expect(client.endpoint.host).to eq "my-cluster.cfg.use1.cache.amazonaws.com"
+      expect(client.endpoint.port).to eq 11211
     end
 
     it 'stores Memcached options' do
-      expect(cache.options[:expires_in]).to eq 24*60*60
-      expect(cache.options[:namespace]).to eq "my_app"
-      expect(cache.options[:compress]).to be true
-    end
-  end
-
-  describe '#method_missing' do
-    subject { cache.dummy_command }
-
-    context 'on refresh time' do
-      let(:options) { { refresh_interval: -1 } }
-
-      it 'refreshes nodes' do
-        expect(cache).to receive(:refresh)
-        subject
-      end
-      it 'send command' do
-        expect(cache).to receive(:dummy_command)
-        subject
-      end
-    end
-    context 'not on refresh time' do
-      it 'doesnt refresh nodes' do
-        expect(cache).not_to receive(:refresh)
-        subject
-      end
-      it 'sends command' do
-        expect(cache).to receive(:dummy_command)
-        subject
-      end
-    end
-
-    context 'connection failed' do
-      let(:dummy_client) {
-        Class.new {
-          def dummy_command
-            raise Memcached::ConnectionFailure
-          end
-        }.new
-      }
-
-      it 'refreshes nodes once' do
-        expect(cache).to receive(:refresh).once
-        begin
-          subject
-        rescue
-        end
-      end
-
-      it 'raises error' do
-        expect { subject }.to raise_error(Memcached::ConnectionFailure)
-      end
+      expect(client.options[:expires_in]).to eq 24*60*60
+      expect(client.options[:namespace]).to eq "my_app"
+      expect(client.options[:compress]).to be true
     end
   end
 
   describe '#clone' do
-    subject { cache.clone }
+    subject { client.clone }
 
     let(:client_options) {
       {
         expires_in: 24*60*60,
         namespace: 'my_app',
-        compress: true
+        compress: true,
+        ttl: 10
       }
     }
     let(:ec_options) {
@@ -113,6 +59,268 @@ describe 'Memcached::ElastiCache::Endpoint' do
       expect(subject.instance_variable_get(:@refresh_interval)).to eq ec_options[:refresh_interval]
       expect(subject.instance_variable_get(:@max_retry_count)).to eq ec_options[:max_retry_count]
       expect(subject.instance_variable_get(:@enable_legacy_ec)).to eq ec_options[:enable_legacy_ec]
+      expect(subject.instance_variable_get(:@default_ttl)).to eq client_options[:ttl]
+    end
+  end
+
+  describe 'memcached client methods' do
+    let(:key) { 'key' }
+    let(:keys) { %w(key1 key2 key3) }
+    let(:value) { 'value' }
+    let(:ttl) { 123 }
+    let(:raw) { true }
+    let(:flags) { 0b0 }
+    let(:offset) { 10 }
+
+    describe '#flush' do
+      subject { client.flush }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached#flush' do
+        expect(m_client).to receive(:flush)
+        subject
+      end
+    end
+
+    describe '#set' do
+      subject { client.set(key, value, ttl: ttl, raw: raw, flags: flags) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #set' do
+        expect(m_client).to receive(:set).with(key, value, ttl: ttl, raw: raw, flags: flags)
+        subject
+      end
+    end
+
+    describe '#get' do
+      subject { client.get(key, raw: raw) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #get' do
+        expect(m_client).to receive(:get).with(key, raw: raw)
+        subject
+      end
+    end
+
+    describe '#get_multi' do
+      subject { client.get_multi(keys, raw: raw) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #get_multi' do
+        expect(m_client).to receive(:get_multi).with(keys, raw: raw)
+        subject
+      end
+    end
+
+    describe '#delete' do
+      subject { client.delete(key) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #delete' do
+        expect(m_client).to receive(:delete).with(key)
+        subject
+      end
+    end
+
+    describe '#add' do
+      subject { client.add(key, value, ttl: ttl, raw: raw, flags: flags) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #add' do
+        expect(m_client).to receive(:add).with(key, value, ttl: ttl, raw: raw, flags: flags)
+        subject
+      end
+    end
+
+    describe '#increment' do
+      subject { client.increment(key, offset) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #increment' do
+        expect(m_client).to receive(:increment).with(key, offset)
+        subject
+      end
+    end
+
+    describe '#decrement' do
+      subject { client.decrement(key, offset) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #decrement' do
+        expect(m_client).to receive(:decrement).with(key, offset)
+        subject
+      end
+    end
+
+    describe '#exist' do
+      subject { client.exist(key) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #exist' do
+        expect(m_client).to receive(:exist).with(key)
+        subject
+      end
+    end
+
+    describe '#replace' do
+      subject { client.replace(key, value, ttl: ttl, raw: raw, flags: flags) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #replace' do
+        expect(m_client).to receive(:replace).with(key, value, ttl: ttl, raw: raw, flags: flags)
+        subject
+      end
+    end
+
+    describe '#prepend' do
+      subject { client.prepend(key, value, ttl: ttl, flags: flags) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #prepend' do
+        expect(m_client).to receive(:prepend).with(key, value, ttl: ttl, flags: flags)
+        subject
+      end
+    end
+
+    describe '#append' do
+      subject { client.append(key, value, ttl: ttl, flags: flags) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #append' do
+        expect(m_client).to receive(:append).with(key, value, ttl: ttl, flags: flags)
+        subject
+      end
+    end
+
+    describe '#namespace' do
+      subject { client.namespace }
+
+      it 'calls memcached #namespace' do
+        expect(m_client).to receive(:namespace)
+        subject
+      end
+    end
+
+    describe '#namespace=' do
+      let(:name) { 'foo' }
+      subject { client.namespace = name }
+
+      it 'calls memcached #namespace' do
+        expect(m_client).to receive(:namespace=).with(name)
+        subject
+      end
+    end
+
+    describe '#touch' do
+      subject { client.touch(key, ttl) }
+
+      it 'calls #refresh_with' do
+        expect(client).to receive(:refresh_with)
+        subject
+      end
+      it 'calls memcached #touch' do
+        expect(m_client).to receive(:touch).with(key, ttl)
+        subject
+      end
+    end
+
+    describe '#reset' do
+      subject { client.reset }
+
+      it 'calls memcached #reset' do
+        expect(m_client).to receive(:reset)
+        subject
+      end
+    end
+  end
+
+  describe '#refresh_with' do
+    subject { client.flush }
+
+    let(:m_client) {
+      Class.new {
+        def flush
+          'dummy'
+        end
+      }.new
+    }
+
+    context 'on refresh time' do
+      let(:options) { { refresh_interval: -1 } }
+
+      it 'refreshes nodes' do
+        expect(client).to receive(:refresh)
+        subject
+      end
+      it 'send command' do
+        expect(m_client).to receive(:flush)
+        subject
+      end
+    end
+    context 'not on refresh time' do
+      it 'doesnt refresh nodes' do
+        expect(client).not_to receive(:refresh)
+        subject
+      end
+      it 'sends command' do
+        expect(m_client).to receive(:flush)
+        subject
+      end
+    end
+    context 'connection failed' do
+      let(:m_client) {
+        Class.new {
+          def flush
+            raise Memcached::ConnectionFailure
+          end
+        }.new
+      }
+      it 'refreshes nodes once' do
+        expect(client).to receive(:refresh).once
+        begin
+          subject
+        rescue
+        end
+      end
+      it 'raises error' do
+        expect { subject }.to raise_error(Memcached::ConnectionFailure)
+      end
     end
   end
 end

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -1,8 +1,8 @@
 require_relative 'spec_helper'
 
-describe 'Dalli::Elasticache::AutoDiscovery::Endpoint' do
+describe 'Memcached::Elasticache::AutoDiscovery::Endpoint' do
   let(:endpoint) do
-    Dalli::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
+    Memcached::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
   end
   
   describe '.new' do

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe 'Memcached::Elasticache::AutoDiscovery::Endpoint' do
   let(:endpoint) do
-    Memcached::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", false)
+    Memcached::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
   end
 
   describe '.new' do

--- a/spec/endpoint_spec.rb
+++ b/spec/endpoint_spec.rb
@@ -2,15 +2,15 @@ require_relative 'spec_helper'
 
 describe 'Memcached::Elasticache::AutoDiscovery::Endpoint' do
   let(:endpoint) do
-    Memcached::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211")
+    Memcached::Elasticache::AutoDiscovery::Endpoint.new("my-cluster.cfg.use1.cache.amazonaws.com:11211", false)
   end
-  
+
   describe '.new' do
     it 'parses host' do
-      endpoint.host.should == "my-cluster.cfg.use1.cache.amazonaws.com"
+      expect(endpoint.host).to eq "my-cluster.cfg.use1.cache.amazonaws.com"
     end
     it 'parses port' do
-      endpoint.port.should == 11211
+      expect(endpoint.port).to eq 11211
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,3 @@
 require "bundler/setup"
 
 require "memcached/elasticache"
-
-RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :should
-  end
-  config.mock_with :rspec do |c|
-    c.syntax = :should
-  end
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require "bundler/setup"
 
-require "dalli/elasticache"
+require "memcached/elasticache"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/stats_response_spec.rb
+++ b/spec/stats_response_spec.rb
@@ -1,9 +1,9 @@
 require_relative 'spec_helper'
 
-describe 'Dalli::Elasticache::AutoDiscovery::StatsResponse' do
+describe 'Memcached::Elasticache::AutoDiscovery::StatsResponse' do
   let :response do
     text = "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\nSTAT version 1.4.14\r\nSTAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\nSTAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\nSTAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\nSTAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\nSTAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\nSTAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\nSTAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\nSTAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\nSTAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\nSTAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\nSTAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\nSTAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\nSTAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\nSTAT evictions 0\r\nSTAT reclaimed 0\r\n"
-    Dalli::Elasticache::AutoDiscovery::StatsResponse.new(text)
+    Memcached::Elasticache::AutoDiscovery::StatsResponse.new(text)
   end
   
   describe '#version' do

--- a/spec/stats_response_spec.rb
+++ b/spec/stats_response_spec.rb
@@ -5,10 +5,10 @@ describe 'Memcached::Elasticache::AutoDiscovery::StatsResponse' do
     text = "STAT pid 1\r\nSTAT uptime 68717\r\nSTAT time 1398885375\r\nSTAT version 1.4.14\r\nSTAT libevent 1.4.13-stable\r\nSTAT pointer_size 64\r\nSTAT rusage_user 0.136008\r\nSTAT rusage_system 0.424026\r\nSTAT curr_connections 5\r\nSTAT total_connections 1159\r\nSTAT connection_structures 6\r\nSTAT reserved_fds 5\r\nSTAT cmd_get 0\r\nSTAT cmd_set 0\r\nSTAT cmd_flush 0\r\nSTAT cmd_touch 0\r\nSTAT cmd_config_get 4582\r\nSTAT cmd_config_set 2\r\nSTAT get_hits 0\r\nSTAT get_misses 0\r\nSTAT delete_misses 0\r\nSTAT delete_hits 0\r\nSTAT incr_misses 0\r\nSTAT incr_hits 0\r\nSTAT decr_misses 0\r\nSTAT decr_hits 0\r\nSTAT cas_misses 0\r\nSTAT cas_hits 0\r\nSTAT cas_badval 0\r\nSTAT touch_hits 0\r\nSTAT touch_misses 0\r\nSTAT auth_cmds 0\r\nSTAT auth_errors 0\r\nSTAT bytes_read 189356\r\nSTAT bytes_written 2906615\r\nSTAT limit_maxbytes 209715200\r\nSTAT accepting_conns 1\r\nSTAT listen_disabled_num 0\r\nSTAT threads 1\r\nSTAT conn_yields 0\r\nSTAT curr_config 1\r\nSTAT hash_power_level 16\r\nSTAT hash_bytes 524288\r\nSTAT hash_is_expanding 0\r\nSTAT expired_unfetched 0\r\nSTAT evicted_unfetched 0\r\nSTAT bytes 0\r\nSTAT curr_items 0\r\nSTAT total_items 0\r\nSTAT evictions 0\r\nSTAT reclaimed 0\r\n"
     Memcached::Elasticache::AutoDiscovery::StatsResponse.new(text)
   end
-  
+
   describe '#version' do
     it 'parses version' do
-      response.version.should == Gem::Version.new("1.4.14")
+      expect(response.version).to eq Gem::Version.new("1.4.14")
     end
   end
 end


### PR DESCRIPTION
This PR includes the following changes:

- Replace [memcached](https://github.com/arthurnn/memcached) with [dalli](https://github.com/petergoldstein/dalli)
- Automatically refresh cluster nodes
- Drop legacy ElastiCache support